### PR TITLE
Support scanning assemblies with missing references

### DIFF
--- a/Runner/AssemblyScanner.cs
+++ b/Runner/AssemblyScanner.cs
@@ -30,7 +30,7 @@ namespace Gauge.CSharp.Runner
             AttributeToMethodInfo[typeof(Step)] = new List<MethodInfo>();
         }
 
-        public void Scan(string path)
+        public void TryAdd(string path)
         {
             Logger.Debug("Loading assembly from : {0}", path);
             Assembly assembly;

--- a/Runner/AssemblyScanner.cs
+++ b/Runner/AssemblyScanner.cs
@@ -10,7 +10,7 @@ namespace Gauge.CSharp.Runner
 {
     public class AssemblyScanner
     {
-        private static readonly Logger Logger = LogManager.GetLogger("Sandbox");
+        private static readonly Logger Logger = LogManager.GetLogger("AssemblyScanner");
 
         public List<Assembly> AssembliesReferencingGaugeLib = new List<Assembly>();
         public List<Type> ScreengrabberTypes = new List<Type>();

--- a/Runner/AssemblyScanner.cs
+++ b/Runner/AssemblyScanner.cs
@@ -1,0 +1,101 @@
+﻿using Gauge.CSharp.Lib;
+using Gauge.CSharp.Lib.Attribute;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Gauge.CSharp.Runner
+{
+    public class AssemblyScanner
+    {
+        private static readonly Logger Logger = LogManager.GetLogger("Sandbox");
+
+        public List<Assembly> AssembliesReferencingGaugeLib = new List<Assembly>();
+        public List<Type> ScreengrabberTypes = new List<Type>();
+        public Dictionary<Type, List<MethodInfo>> AttributeToMethodInfo;
+
+        public AssemblyScanner()
+        {
+            AttributeToMethodInfo = new Dictionary<Type, List<MethodInfo>>();
+            AttributeToMethodInfo[typeof(BeforeSuite)] = new List<MethodInfo>();
+            AttributeToMethodInfo[typeof(AfterSuite)] = new List<MethodInfo>();
+            AttributeToMethodInfo[typeof(BeforeSpec)] = new List<MethodInfo>();
+            AttributeToMethodInfo[typeof(AfterSpec)] = new List<MethodInfo>();
+            AttributeToMethodInfo[typeof(BeforeScenario)] = new List<MethodInfo>();
+            AttributeToMethodInfo[typeof(AfterScenario)] = new List<MethodInfo>();
+            AttributeToMethodInfo[typeof(BeforeStep)] = new List<MethodInfo>();
+            AttributeToMethodInfo[typeof(AfterStep)] = new List<MethodInfo>();
+            AttributeToMethodInfo[typeof(Step)] = new List<MethodInfo>();
+        }
+
+        public void Scan(string path)
+        {
+            Logger.Debug("Loading assembly from : {0}", path);
+            Assembly assembly;
+            try
+            {
+                // Load assembly for reflection only to avoid exceptions when referenced assemblies cannot be found
+                assembly = Assembly.ReflectionOnlyLoadFrom(path);
+            }
+            catch (Exception e)
+            {
+                Logger.Warn("Failed to scan assembly {0}", path);
+                return;
+            }
+
+            var isReferencingGaugeLib = assembly.GetReferencedAssemblies()
+                .Select(name => name.Name)
+                .Contains(typeof(Step).Assembly.GetName().Name);
+
+            var loadableTypes = isReferencingGaugeLib ? GetLoadableTypes(assembly) : new List<Type>();
+
+            // Load assembly so that code can be executed
+            var fullyLoadedAssembly = Assembly.Load(AssemblyName.GetAssemblyName(path));
+            var types = GetFullyLoadedTypes(loadableTypes, fullyLoadedAssembly);
+
+            if (isReferencingGaugeLib)
+                AssembliesReferencingGaugeLib.Add(fullyLoadedAssembly);
+
+            ScanForScreengrabber(types);
+            ScanForMethodAttributes(types);
+        }
+
+        private IEnumerable<Type> GetFullyLoadedTypes(IEnumerable<Type> loadableTypes, Assembly fullyLoadedAssembly)
+        {
+            foreach (var type in loadableTypes)
+                yield return fullyLoadedAssembly.GetType(type.FullName);
+        }
+
+        private void ScanForMethodAttributes(IEnumerable<Type> types)
+        {
+            foreach (var type in AttributeToMethodInfo.Keys)
+            {
+                var methodInfos = types
+                    .SelectMany(t => t.GetMethods().Where(info => info.GetCustomAttributes(type).Any()));
+                AttributeToMethodInfo[type].AddRange(methodInfos);
+            }
+        }
+
+        private void ScanForScreengrabber(IEnumerable<Type> types)
+        {
+            var implementingTypes =
+                types.Where(type => type.GetInterfaces().Any(t => t.FullName == typeof(IScreenGrabber).FullName));
+            ScreengrabberTypes.AddRange(implementingTypes);
+        }
+
+        private IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                Logger.Warn("Could not scan all types in assembly {0}", assembly.CodeBase);
+                return e.Types.Where(type => type != null);
+            }
+        }
+    }
+}

--- a/Runner/AssemblyScanner.cs
+++ b/Runner/AssemblyScanner.cs
@@ -68,7 +68,7 @@ namespace Gauge.CSharp.Runner
             {
                 var fullyLoadedType = fullyLoadedAssembly.GetType(type.FullName);
                 if (fullyLoadedType == null)
-                    Logger.Warn("Cannot not scan type '{0}'", type.FullName);                    
+                    Logger.Warn("Cannot scan type '{0}'", type.FullName);                    
                 else
                     yield return fullyLoadedType;
             }

--- a/Runner/AssemblyScanner.cs
+++ b/Runner/AssemblyScanner.cs
@@ -11,10 +11,10 @@ namespace Gauge.CSharp.Runner
     public class AssemblyScanner
     {
         private static readonly Logger Logger = LogManager.GetLogger("AssemblyScanner");
+        private Dictionary<Type, List<MethodInfo>> AttributeToMethodInfo;
 
         public List<Assembly> AssembliesReferencingGaugeLib = new List<Assembly>();
         public List<Type> ScreengrabberTypes = new List<Type>();
-        public Dictionary<Type, List<MethodInfo>> AttributeToMethodInfo;
 
         public AssemblyScanner()
         {
@@ -28,6 +28,11 @@ namespace Gauge.CSharp.Runner
             AttributeToMethodInfo[typeof(BeforeStep)] = new List<MethodInfo>();
             AttributeToMethodInfo[typeof(AfterStep)] = new List<MethodInfo>();
             AttributeToMethodInfo[typeof(Step)] = new List<MethodInfo>();
+        }
+
+        public List<MethodInfo> GetHookMethods(Type type)
+        {
+            return AttributeToMethodInfo[type];
         }
 
         public void TryAdd(string path)

--- a/Runner/Gauge.CSharp.Runner.csproj
+++ b/Runner/Gauge.CSharp.Runner.csproj
@@ -109,6 +109,7 @@
     <Reference Include="System.Text.Encoding, Version=4.0.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyScanner.cs" />
     <Compile Include="ClassInstanceManager.cs" />
     <Compile Include="Converters\IParamConverter.cs" />
     <Compile Include="ErrorCodeAggregator.cs" />

--- a/Runner/Sandbox.cs
+++ b/Runner/Sandbox.cs
@@ -189,5 +189,10 @@ namespace Gauge.CSharp.Runner
                 Logger.Debug("No implementation of IScreenGrabber found.");
             }
         }
+
+        public override object InitializeLifetimeService()
+        {
+            return null;
+        }
     }
 }

--- a/Runner/Sandbox.cs
+++ b/Runner/Sandbox.cs
@@ -173,7 +173,11 @@ namespace Gauge.CSharp.Runner
 
         private void LocateTargetLibAssembly()
         {
-            TargetLibAssembly = typeof(Step).Assembly;
+            var targetLibAssemblyName = AssemblyScanner.AssembliesReferencingGaugeLib
+                .Select(a => a.GetReferencedAssemblies().Single(ra => ra.Name == GaugeLibAssembleName))
+                .Distinct()
+                .Single();
+            TargetLibAssembly = Assembly.Load(targetLibAssemblyName);
             Logger.Debug("Target Lib loaded : {0}, from {1}", TargetLibAssembly.FullName, TargetLibAssembly.Location);
         }
 

--- a/Runner/Sandbox.cs
+++ b/Runner/Sandbox.cs
@@ -195,7 +195,7 @@ namespace Gauge.CSharp.Runner
 
         private void LocateTargetLibAssembly()
         {
-            TargetLibAssembly = ScannedAssemblies.First(assembly => assembly.GetName().Name == GaugeLibAssembleName);
+            TargetLibAssembly = typeof(Step).Assembly;
             Logger.Debug("Target Lib loaded : {0}, from {1}", TargetLibAssembly.FullName, TargetLibAssembly.Location);
         }
 

--- a/Runner/Sandbox.cs
+++ b/Runner/Sandbox.cs
@@ -69,20 +69,20 @@ namespace Gauge.CSharp.Runner
         public IHookRegistry GetHookRegistry()
         {
             var hookRegistry = new HookRegistry(this);
-            hookRegistry.AddBeforeSuiteHooks(AssemblyScanner.AttributeToMethodInfo[typeof(BeforeSuite)]);
-            hookRegistry.AddAfterSuiteHooks(AssemblyScanner.AttributeToMethodInfo[typeof(AfterSuite)]);
-            hookRegistry.AddBeforeSpecHooks(AssemblyScanner.AttributeToMethodInfo[typeof(BeforeSpec)]);
-            hookRegistry.AddAfterSpecHooks(AssemblyScanner.AttributeToMethodInfo[typeof(AfterSpec)]);
-            hookRegistry.AddBeforeScenarioHooks(AssemblyScanner.AttributeToMethodInfo[typeof(BeforeScenario)]);
-            hookRegistry.AddAfterScenarioHooks(AssemblyScanner.AttributeToMethodInfo[typeof(AfterScenario)]);
-            hookRegistry.AddBeforeStepHooks(AssemblyScanner.AttributeToMethodInfo[typeof(BeforeStep)]);
-            hookRegistry.AddAfterStepHooks(AssemblyScanner.AttributeToMethodInfo[typeof(AfterStep)]);
+            hookRegistry.AddBeforeSuiteHooks(AssemblyScanner.GetHookMethods(typeof(BeforeSuite)));
+            hookRegistry.AddAfterSuiteHooks(AssemblyScanner.GetHookMethods(typeof(AfterSuite)));
+            hookRegistry.AddBeforeSpecHooks(AssemblyScanner.GetHookMethods(typeof(BeforeSpec)));
+            hookRegistry.AddAfterSpecHooks(AssemblyScanner.GetHookMethods(typeof(AfterSpec)));
+            hookRegistry.AddBeforeScenarioHooks(AssemblyScanner.GetHookMethods(typeof(BeforeScenario)));
+            hookRegistry.AddAfterScenarioHooks(AssemblyScanner.GetHookMethods(typeof(AfterScenario)));
+            hookRegistry.AddBeforeStepHooks(AssemblyScanner.GetHookMethods(typeof(BeforeStep)));
+            hookRegistry.AddAfterStepHooks(AssemblyScanner.GetHookMethods(typeof(AfterStep)));
             return hookRegistry;
         }
 
         public List<MethodInfo> GetStepMethods()
         {
-            return AssemblyScanner.AttributeToMethodInfo[typeof(Step)];
+            return AssemblyScanner.GetHookMethods(typeof(Step));
         }
 
         public List<string> GetAllStepTexts()

--- a/Runner/Sandbox.cs
+++ b/Runner/Sandbox.cs
@@ -168,7 +168,7 @@ namespace Gauge.CSharp.Runner
         private void EnumerateAndLoadAssemblies()
         {
             foreach (var path in Directory.EnumerateFiles(Utils.GetGaugeBinDir(), "*.dll", SearchOption.TopDirectoryOnly))
-                AssemblyScanner.Scan(path);
+                AssemblyScanner.TryAdd(path);
         }
 
         private void LocateTargetLibAssembly()


### PR DESCRIPTION
The current Sandbox loader scans all assemblies in gauge-bin folder using `Assembly.load()` and `GetTypes()` on these assemblies.

If one of the types in the assemblies inherits from an external type, the referenced assembly will be automatically loaded. The runner crashes if this assembly cannot be found, even if the type has no Step implementations or is not nescessary for the tests.

This pull requests uses `Assembly.ReflectionOnlyLoadFrom()` instead which makes scanning for types possible when referenced assemblies are not available.