### PR TITLE
Improve dev experience on Mono

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@ obj
 packages
 *.nupkg
 *.csproj.user
+*.userprefs
 artifacts/
 *.Sln.ide
 IntegrationTestSample/gauge-bin
 IntegrationTestSample/logs
 IntegrationTestSample/reports
+

--- a/Runner.UnitTests/UtilsTest.cs
+++ b/Runner.UnitTests/UtilsTest.cs
@@ -28,12 +28,13 @@ namespace Gauge.CSharp.Runner.UnitTests
         [Test]
         public void ShouldGetCustomBuildPathFromEnv()
         {
-            Environment.SetEnvironmentVariable("GAUGE_PROJECT_ROOT", @"C:\Blah");
+            var driveRoot = Path.GetPathRoot(Directory.GetCurrentDirectory());
+            Environment.SetEnvironmentVariable("GAUGE_PROJECT_ROOT", Path.Combine(driveRoot, "Blah"));
 
-            var imaginaryPath = string.Format("Foo{0}Bar", Path.DirectorySeparatorChar);
+            var imaginaryPath = Path.Combine("Foo", "Bar");;
             Environment.SetEnvironmentVariable("gauge_custom_build_path", imaginaryPath);
             var gaugeBinDir = Utils.GetGaugeBinDir();
-            Assert.AreEqual(@"C:\Blah\Foo\Bar", gaugeBinDir);
+            Assert.AreEqual(Path.Combine(driveRoot, "Blah", "Foo", "Bar"), gaugeBinDir);
 
             Environment.SetEnvironmentVariable("GAUGE_PROJECT_ROOT", string.Empty);
             Environment.SetEnvironmentVariable("gauge_custom_build_path", string.Empty);


### PR DESCRIPTION
Make file paths cross-platform in unit tests, and ignore Xamarin Studio user-specific files.

There are some additional file path fixes that are needed in the integration tests, but even with those fixes the tests don't pass as a suite yet (although they do pass individually); I want to get them passing before I submit the fixes.