### PR TITLE
Fix bugs when loading IClassInstanceManager implementations.

### DIFF
--- a/Runner.UnitTests/AssemblyLoaderTests.cs
+++ b/Runner.UnitTests/AssemblyLoaderTests.cs
@@ -100,7 +100,7 @@ namespace Gauge.CSharp.Runner.UnitTests
         [Test]
         public void ShouldGetClassInstanceManagerTypes()
         {
-            Assert.Contains(_mockInstanceManagerType, _assemblyLoader.ClassInstanceManagerTypes);
+            Assert.Contains(_mockInstanceManagerType.Object, _assemblyLoader.ClassInstanceManagerTypes);
         }
     }
 }

--- a/Runner/AssemblyLoader.cs
+++ b/Runner/AssemblyLoader.cs
@@ -171,13 +171,11 @@ namespace Gauge.CSharp.Runner
             ScreengrabberTypes.AddRange(implementingTypes);
         }
 
-
         private void ScanForInstanceManager(IEnumerable<Type> types)
         {
-            var implementingTypes = types.Where(type => type.GetInterfaces().Any(t => t.FullName == "Gauge.CSharp.Lib.InstanceManagement.IClassInstanceManager"));
+            var implementingTypes = types.Where(type => type.GetInterfaces().Any(t => t.FullName == "Gauge.CSharp.Lib.IClassInstanceManager"));
             ClassInstanceManagerTypes.AddRange(implementingTypes);
         }
-
 
         private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
         {

--- a/Runner/Sandbox.cs
+++ b/Runner/Sandbox.cs
@@ -355,7 +355,7 @@ namespace Gauge.CSharp.Runner
             else
             {
                 logger.Debug("Loading : {0}", instanceManagerType.FullName);
-                _classInstanceManager = _libAssembly.CreateInstance(instanceManagerType.FullName);
+                _classInstanceManager = Activator.CreateInstance(instanceManagerType);
             }
 
             _classInstanceManager = _classInstanceManager ??


### PR DESCRIPTION
This is my fix for a problem I ran into where my implementation of `IClassInstanceManager` was not loaded.

First, when we scan for implementations of IClassInstanceManager, we need to use the correct namespace. In the past, this was done with greater type-safety by using `typeof(IClassInstanceManager).FullName` instead of a string literal. I held off on going back to that, on the assumption that there was a good reason for using strings. Should we make that further change?

Secondly, when Sandbox.cs instantiates the type that implements IClassInstanceManager, we need to use `Activator.CreateInstance` instead of `_libAssembly.CreateInstance`. The Activator method can instantiate any type, while the Assembly method can only create types in the assembly.