### PR TITLE
Build Gauge project in Debug mode so .pdb files are produced and Visual Studio can attach to the Gauge.CSharpRunner.exe and Visual Studio can attach to process and hit Spec breakpoints

### DIFF
--- a/Runner/GaugeProjectBuilder.cs
+++ b/Runner/GaugeProjectBuilder.cs
@@ -37,7 +37,7 @@ namespace Gauge.CSharp.Runner
             var gaugeBinDir = Utils.GetGaugeBinDir();
             try
             {
-                var properties = new FSharpList<Tuple<string, string>>(Tuple.Create("Configuration", "Release"),
+                var properties = new FSharpList<Tuple<string, string>>(Tuple.Create("Configuration", "Debug"),
                     FSharpList<Tuple<string, string>>.Empty);
                 properties = new FSharpList<Tuple<string, string>>(Tuple.Create("Platform", "Any CPU"), properties);
                 properties = new FSharpList<Tuple<string, string>>(Tuple.Create("OutputPath", gaugeBinDir), properties);


### PR DESCRIPTION
Having .pdb files produced by the GaugeProjectBuilder allows a debugger (ex: VS) to attach to the Gauge.CSharpRunner.exe process and hit breakpoints in Spec code.  I don't see any downside to building in Debug mode but would be interested in knowing if there's something I haven't considered.  This change meets my needs as I've found that I can attach to the process with this change in place.