### PR TITLE
Make CSharp Runner build Configuration and Platform Configurable

### DIFF
--- a/Gauge.Project.Skel/env/default/csharp.properties
+++ b/Gauge.Project.Skel/env/default/csharp.properties
@@ -1,2 +1,8 @@
 # Holds the location of the created Gauge project
 GAUGE_CSHARP_PROJECT_FILE = $gaugeprojectfile$
+
+# The build configuration when running tests for the Gauge project
+GAUGE_CSHARP_PROJECT_CONFIG = Debug
+
+# The build platform when running tests for the Gauge project
+GAUGE_CSHARP_PROJECT_PLATFORM = Any CPU

--- a/Runner/Gauge.CSharp.Runner.csproj
+++ b/Runner/Gauge.CSharp.Runner.csproj
@@ -49,6 +49,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>Gauge.CSharp.Runner.Program</StartupObject>

--- a/Runner/GaugeProjectBuilder.cs
+++ b/Runner/GaugeProjectBuilder.cs
@@ -34,12 +34,14 @@ namespace Gauge.CSharp.Runner
         public bool BuildTargetGaugeProject()
         {
             var projectFullPath = GetProjectFullPath();
+            var projectConfig = GetProjectConfiguration();
+            var projectPlatform = GetProjectPlatform();
             var gaugeBinDir = Utils.GetGaugeBinDir();
             try
             {
-                var properties = new FSharpList<Tuple<string, string>>(Tuple.Create("Configuration", "Debug"),
+                var properties = new FSharpList<Tuple<string, string>>(Tuple.Create("Configuration", projectConfig),
                     FSharpList<Tuple<string, string>>.Empty);
-                properties = new FSharpList<Tuple<string, string>>(Tuple.Create("Platform", "Any CPU"), properties);
+                properties = new FSharpList<Tuple<string, string>>(Tuple.Create("Platform", projectPlatform), properties);
                 properties = new FSharpList<Tuple<string, string>>(Tuple.Create("OutputPath", gaugeBinDir), properties);
                 MSBuildHelper.build(FuncConvert.ToFSharpFunc(delegate(MSBuildHelper.MSBuildParams input)
                 {
@@ -70,6 +72,24 @@ namespace Gauge.CSharp.Runner
                 throw new NotAValidGaugeProjectException();
             var projectFullPath = projectFileList.First();
             return projectFullPath;
+        }
+
+        private static string GetProjectConfiguration()
+        {
+            var csprojEnvVariable = Utils.TryReadEnvValue("GAUGE_CSHARP_PROJECT_CONFIG");
+            if (!string.IsNullOrEmpty(csprojEnvVariable))
+                return csprojEnvVariable;
+
+            return "Debug";
+        }
+
+        private static string GetProjectPlatform()
+        {
+            var csprojEnvVariable = Utils.TryReadEnvValue("GAUGE_CSHARP_PROJECT_PLATFORM");
+            if (!string.IsNullOrEmpty(csprojEnvVariable))
+                return csprojEnvVariable;
+
+            return "Any CPU";
         }
     }
 }


### PR DESCRIPTION
Related to issue  #131 (Make CSharp Runner build Configuration and Platform Configurable)

Allows Configuration and Platform to be configurable in csharp.properties